### PR TITLE
Use basename of project path if there isn't a displayName

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,21 +24,27 @@ class JestPluginProjects {
   _setProjects(projects) {
     if (!this._projectNames) {
       console.log(projects.slice(0, 2).map(p => p.config));
-      this._projectNames = projects.map(p => {
-        const projectName = p.config.displayName || path.basename(p.config.rootDir);
 
-        if (!projectName) {
-          throw new Error(`
+      const projectNameSet = projects.reduce(
+        (state, p) => {
+          const projectName = p.config.displayName || path.basename(p.config.rootDir);
+          if (state.has(projectName)) {
+            throw new Error(`
 
-Project in "${p.config.rootDir}" does not have a \`displayName\`.
-In order to use \`jest-watch-select-projects\`, please add \`displayName\` to all the projects.
+Found multiple projects in the same directory. "${p.config.rootDir}"
 
+Add a \`displayName\` to at least one of them to prevent name collision.
     - More info: https://facebook.github.io/jest/docs/en/configuration.html#projects-array-string-projectconfig
-          `);
-        }
 
-        return projectName;
-      });
+            `);
+          } else {
+            return new Set([...state, projectName]);
+          }
+        },
+        new Set()
+      );
+
+      this._projectNames = [...projectNameSet];
       this._setActiveProjects(this._projectNames);
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -27,19 +27,31 @@ class JestPluginProjects {
 
       const projectNameSet = projects.reduce(
         (state, p) => {
-          const projectName = p.config.displayName || path.basename(p.config.rootDir);
-          if (state.has(projectName)) {
+          const { displayName, rootDir } = p.config;
+          if (state.has(displayName)) {
             throw new Error(`
 
-Found multiple projects in the same directory. "${p.config.rootDir}"
+Found multiple projects with the same \`displayName\`: "${displayName}"
+
+Change the \`displayName\` on at least one of them to prevent name collision.
+    - More info: https://facebook.github.io/jest/docs/en/configuration.html#projects-array-string-projectconfig
+
+            `);
+          }
+
+          const basename = path.basename(rootDir);
+          if (state.has(baseName)) {
+            throw new Error(`
+
+Found multiple projects with the same directory basename: "${basename}"
 
 Add a \`displayName\` to at least one of them to prevent name collision.
     - More info: https://facebook.github.io/jest/docs/en/configuration.html#projects-array-string-projectconfig
 
             `);
-          } else {
-            return new Set([...state, projectName]);
           }
+
+          return new Set([...state, projectName]);
         },
         new Set()
       );

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const chalk = require('chalk');
 const prompts = require('prompts');
 const ansiEscapes = require('ansi-escapes');
 const { readConfig } = require('jest-config');
+const path = require('path');
 
 class JestPluginProjects {
   constructor() {
@@ -24,7 +25,9 @@ class JestPluginProjects {
     if (!this._projectNames) {
       console.log(projects.slice(0, 2).map(p => p.config));
       this._projectNames = projects.map(p => {
-        if (!p.config.displayName) {
+        const projectName = p.config.displayName || path.basename(p.config.rootDir);
+
+        if (!projectName) {
           throw new Error(`
 
 Project in "${p.config.rootDir}" does not have a \`displayName\`.
@@ -34,7 +37,7 @@ In order to use \`jest-watch-select-projects\`, please add \`displayName\` to al
           `);
         }
 
-        return p.config.displayName;
+        return projectName;
       });
       this._setActiveProjects(this._projectNames);
     }


### PR DESCRIPTION
We don't have the option to specify a `displayName` when projects are configured using a string glob:

```json
{
  "projects": ["<rootDir>", "<rootDir>/examples/*"]
}
```

As a fallback, we can use the `path.basename` of the project `rootDir` as the fallback name.