### PR TITLE
initialize this._projectNames

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const path = require('path');
 class JestPluginProjects {
   constructor() {
     this._activeProjects = {};
+    this._projectNames = [];
   }
 
   apply(jestHook) {
@@ -22,7 +23,7 @@ class JestPluginProjects {
   onKey() {}
 
   _setProjects(projects) {
-    if (!this._projectNames) {
+    if (!this._projectNames.length) {
       const projectNameSet = projects.reduce(
         (state, p) => {
           const { displayName, rootDir } = p.config;


### PR DESCRIPTION
Jest calls an internal `checkForConflicts` which in turn calls `getUsageInfo` right before it calls `apply` so the `_projectNames` property was unset resulting in the #4 error.

Initializing it to an empty array fixes things.

cc @rogeliog (this should be a pretty quick and easy merge)

Thanks!

Closes #4