### PR TITLE
fix displayName object configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,9 @@
     "execa": "0.8.0",
     "jest": "23.0.1",
     "prettier": "1.13.0"
+  },
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "all"
   }
 }


### PR DESCRIPTION
https://github.com/facebook/jest/pull/8025 added the possibility to specify the the `displayName` as `{name: string, color: string}`. Using this format caused jest-watch-select-projects to show `[object Object]`. This PR makes sure that the new format is handled correctly.
Tested on a Jest multi-project setup including projects configured with both string and object `displayName`s.
I've also had to add a prettier configuration matching the existing code so that there are no unrelated formatting changes to `index.js`